### PR TITLE
Remove tests from generating source maps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop, feature/*, hotfix/*, support/*, release/* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop, feature/*, hotfix/*, support/*, release/* ]
 
 jobs:
   build:

--- a/UnitTests/SassFileWatcherTests.cs
+++ b/UnitTests/SassFileWatcherTests.cs
@@ -35,7 +35,12 @@ namespace LiveSassCompileUnitTests
             _testDestinationPath = Path.Combine(_testRootPath, "Destination");
             Directory.CreateDirectory(_testDestinationPath);
 
-            _testOptions = new SassFileWatcherOptions { SourcePath = _testSourcePath, DestinationPath = _testDestinationPath, CompileOnStart = false };
+            _testOptions = new SassFileWatcherOptions { 
+                SourcePath = _testSourcePath, 
+                DestinationPath = _testDestinationPath, 
+                CompileOnStart = false,
+                GenerateSourceMaps = false
+            };
         }
 
 


### PR DESCRIPTION
Some tests failed because of the source map file generation.